### PR TITLE
Fix the hostnames of Cassy and Reaper

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -212,8 +212,8 @@ $ ssh -F ssh.cfg scalar-blue-1.internal.scalar-labs.com
 $ ssh -F ssh.cfg scalar-blue-2.internal.scalar-labs.com
 $ ssh -F ssh.cfg scalar-blue-3.internal.scalar-labs.com
 
-$ ssh -F ssh.cfg cassy.internal.scalar-labs.com
-$ ssh -F ssh.cfg reaper.internal.scalar-labs.com
+$ ssh -F ssh.cfg cassy-1.internal.scalar-labs.com
+$ ssh -F ssh.cfg reaper-1.internal.scalar-labs.com
 
 $ ssh -F ssh.cfg envoy-1.internal.scalar-labs.com
 $ ssh -F ssh.cfg envoy-2.internal.scalar-labs.com


### PR DESCRIPTION
I fixed the hostnames of Cassy and Reaper corrected to numbered names.