### PR TITLE
Fix kubernetes default version to 1.19

### DIFF
--- a/aws/kubernetes/example.tfvars
+++ b/aws/kubernetes/example.tfvars
@@ -2,7 +2,7 @@ region = "ap-northeast-1"
 
 kubernetes_cluster = {
   # name                                 = "scalar-kubernetes"
-  # kubernetes_version                   = "1.16"
+  # kubernetes_version                   = "1.19"
   # cluster_enabled_log_types            = ""
   # cluster_log_retention_in_days        = "90"
   # cluster_log_kms_key_id               = ""

--- a/azure/kubernetes/example.tfvars
+++ b/azure/kubernetes/example.tfvars
@@ -2,10 +2,9 @@
 kubernetes_cluster = {
   # name                      = "scalar-kubernetes"
   # dns_prefix                = "scalar-kubernetes"
-  # kubernetes_version        = "1.16.13"
+  # kubernetes_version        = "1.19.7"
   # admin_username            = "azureuser"
   # role_based_access_control = "true"
-  # kube_dashboard            = "true"
   # public_cluster_enabled    = "false"
 }
 


### PR DESCRIPTION
# Description

https://github.com/scalar-labs/scalar-terraform/pull/290/

# Done
- Fix default version for k8s module.
- Delete `kube_dashboard` option.