### PR TITLE
Remove reference to cassandra remote state from scalardl module

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -175,13 +175,7 @@ user_name = centos
 
 ```
 $ terraform output
-cassandra_provision_ids = [
-  "4019088576544490630",
-  "656319024837932240",
-  "2469094098071954264",
-]
 cassandra_resource_count = 3
-cassandra_start_on_initial_boot = false
 ```
 
 ### Scalar DL

--- a/aws/cassandra/output.tf
+++ b/aws/cassandra/output.tf
@@ -2,14 +2,6 @@ output "cassandra_resource_count" {
   value = module.cassandra.cassandra_resource_count
 }
 
-output "cassandra_provision_ids" {
-  value = module.cassandra.cassandra_provision_ids
-}
-
-output "cassandra_start_on_initial_boot" {
-  value = module.cassandra.cassandra_start_on_initial_boot
-}
-
 output "inventory_ini" {
   value = module.cassandra.inventory_ini
 }

--- a/aws/scalardl/locals.tf
+++ b/aws/scalardl/locals.tf
@@ -22,7 +22,6 @@ locals {
     green_subnet_ids   = join(",", data.terraform_remote_state.network.outputs.subnet_map["scalardl_green"])
   }
 
-  database = lookup(var.scalardl, "database", "cassandra")
 
   custom_tags = data.terraform_remote_state.network.outputs.custom_tags
 }

--- a/aws/scalardl/locals.tf
+++ b/aws/scalardl/locals.tf
@@ -22,6 +22,5 @@ locals {
     green_subnet_ids   = join(",", data.terraform_remote_state.network.outputs.subnet_map["scalardl_green"])
   }
 
-
   custom_tags = data.terraform_remote_state.network.outputs.custom_tags
 }

--- a/aws/scalardl/locals.tf
+++ b/aws/scalardl/locals.tf
@@ -24,10 +24,5 @@ locals {
 
   database = lookup(var.scalardl, "database", "cassandra")
 
-  cassandra = {
-    start_on_initial_boot = local.database == "cassandra" ? data.terraform_remote_state.cassandra[0].outputs.cassandra_start_on_initial_boot : false
-    provision_ids         = local.database == "cassandra" ? join(",", data.terraform_remote_state.cassandra[0].outputs.cassandra_provision_ids) : ""
-  }
-
   custom_tags = data.terraform_remote_state.network.outputs.custom_tags
 }

--- a/aws/scalardl/main.tf
+++ b/aws/scalardl/main.tf
@@ -2,7 +2,7 @@ module "scalardl" {
   source = "git::https://github.com/scalar-labs/scalar-terraform.git//modules/aws/scalardl?ref=master"
 
   # Required Variables (Use remote state)
-  network   = local.network
+  network = local.network
 
   # Optional Variables
   base     = var.base

--- a/aws/scalardl/main.tf
+++ b/aws/scalardl/main.tf
@@ -3,7 +3,6 @@ module "scalardl" {
 
   # Required Variables (Use remote state)
   network   = local.network
-  cassandra = local.cassandra
 
   # Optional Variables
   base     = var.base

--- a/aws/scalardl/remote.tf
+++ b/aws/scalardl/remote.tf
@@ -5,13 +5,3 @@ data "terraform_remote_state" "network" {
     path = "../network/terraform.tfstate"
   }
 }
-
-data "terraform_remote_state" "cassandra" {
-  count = local.database == "cassandra" ? 1 : 0
-
-  backend = "local"
-
-  config = {
-    path = "../cassandra/terraform.tfstate"
-  }
-}

--- a/aws/scalardl/remote.tf.s3
+++ b/aws/scalardl/remote.tf.s3
@@ -7,15 +7,3 @@ data "terraform_remote_state" "network" {
     region = "ap-northeast-1"
   }
 }
-
-data "terraform_remote_state" "cassandra" {
-  count = local.database == "cassandra" ? 1 : 0
-
-  backend = "s3"
-
-  config = {
-    bucket = "example-scalar-tfstate"
-    key    = "cassandra/terraform.tfstate"
-    region = "ap-northeast-1"
-  }
-}

--- a/azure/README.md
+++ b/azure/README.md
@@ -187,13 +187,7 @@ user_name = centos
 
 ```
 $ terraform output
-cassandra_provision_ids = [
-  "4019088576544490630",
-  "656319024837932240",
-  "2469094098071954264",
-]
 cassandra_resource_count = 3
-cassandra_start_on_initial_boot = false
 ```
 
 ### Scalar DL

--- a/azure/cassandra/output.tf
+++ b/azure/cassandra/output.tf
@@ -2,14 +2,6 @@ output "cassandra_resource_count" {
   value = module.cassandra.cassandra_resource_count
 }
 
-output "cassandra_provision_ids" {
-  value = module.cassandra.cassandra_provision_ids
-}
-
-output "cassandra_start_on_initial_boot" {
-  value = module.cassandra.cassandra_start_on_initial_boot
-}
-
 output "inventory_ini" {
   value = module.cassandra.inventory_ini
 }

--- a/azure/scalardl/locals.tf
+++ b/azure/scalardl/locals.tf
@@ -25,11 +25,6 @@ locals {
 
   database = lookup(var.scalardl, "database", "cassandra")
 
-  cassandra = {
-    start_on_initial_boot = local.database == "cassandra" ? data.terraform_remote_state.cassandra[0].outputs.cassandra_start_on_initial_boot : false
-    provision_ids         = local.database == "cassandra" ? join(",", data.terraform_remote_state.cassandra[0].outputs.cassandra_provision_ids) : ""
-  }
-
   scalardl = (local.database == "cosmos" ? merge(var.scalardl, {
     database_contact_points = data.terraform_remote_state.cosmosdb[0].outputs.cosmosdb_account_endpoint
     database_contact_port   = 1

--- a/azure/scalardl/main.tf
+++ b/azure/scalardl/main.tf
@@ -2,7 +2,7 @@ module "scalardl" {
   source = "git::https://github.com/scalar-labs/scalar-terraform.git//modules/azure/scalardl?ref=master"
 
   # Required Variables (Use remote state)
-  network   = local.network
+  network = local.network
 
   # Optional Variables
   base     = var.base

--- a/azure/scalardl/main.tf
+++ b/azure/scalardl/main.tf
@@ -3,7 +3,6 @@ module "scalardl" {
 
   # Required Variables (Use remote state)
   network   = local.network
-  cassandra = local.cassandra
 
   # Optional Variables
   base     = var.base

--- a/azure/scalardl/remote.tf
+++ b/azure/scalardl/remote.tf
@@ -6,16 +6,6 @@ data "terraform_remote_state" "network" {
   }
 }
 
-data "terraform_remote_state" "cassandra" {
-  count = local.database == "cassandra" ? 1 : 0
-
-  backend = "local"
-
-  config = {
-    path = "../cassandra/terraform.tfstate"
-  }
-}
-
 data "terraform_remote_state" "cosmosdb" {
   count = local.database == "cosmos" ? 1 : 0
 

--- a/azure/scalardl/remote.tf.azurerm
+++ b/azure/scalardl/remote.tf.azurerm
@@ -9,19 +9,6 @@ data "terraform_remote_state" "network" {
   }
 }
 
-data "terraform_remote_state" "cassandra" {
-  count = local.database == "cassandra" ? 1 : 0
-
-  backend = "azurerm"
-
-  config = {
-    resource_group_name  = "example-tfstate"
-    storage_account_name = "exampletfstate"
-    container_name       = "tfstate"
-    key                  = "cassandra/terraform.tfstate"
-  }
-}
-
 data "terraform_remote_state" "cosmosdb" {
   count = local.database == "cosmos" ? 1 : 0
 


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8836

There is no need to reference the values of `cassandra_provision_ids` and `cassandra_start_on_initial_boot` from the scalardl module.

This PR is necessary when scalar-labs/scalar-terraform#303 is merged.
